### PR TITLE
Fix www prefix not working properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ general, you can go ahead and create an issue or PR. Keep in mind:
 
 We depend on Debian-style `apache2`, so all you really need to do is:
 1. Configure DNS records
-2. Get a holetopia.com TLS certificate via certbot
+2. Get a (www.)holetopia.com TLS certificate via certbot
 3. Run the following:
 
 ```sh

--- a/holetopia.com
+++ b/holetopia.com
@@ -1,2 +1,3 @@
 @ 86400 IN SOA ns1.gandi.net. hostmaster.gandi.net. 1735924731 10800 3600 604800 10800
 @ 10800 IN A 100.33.109.220
+www 10800 IN CNAME holetopia.com.

--- a/holetopia.conf
+++ b/holetopia.conf
@@ -1,5 +1,6 @@
 <VirtualHost *:80>
     ServerName holetopia.com
+    ServerAlias www.holetopia.com
 
     RewriteEngine On
     RewriteCond %{REQUEST_URI} !^/.well-known/acme-challenge/
@@ -8,6 +9,7 @@
 
 <VirtualHost *:443>
     ServerName holetopia.com
+    ServerAlias www.holetopia.com
 
     SSLEngine on
     SSLCertificateFile      /etc/letsencrypt/live/holetopia.com/fullchain.pem


### PR DESCRIPTION
## Objectives

Going to `www.holetopia.com` didn't work originally, so this PR makes it equivalent to `holetopia.com`.

## Detailed changes

1. Added a CNAME DNS record for the `www` subdomain
2. expanded SSL certificate to include new subdomain
3. Added ServerAlias to httpd config for that subdomain